### PR TITLE
getAzureTeams group members mag niet failen

### DIFF
--- a/lib/MsGroup.pm
+++ b/lib/MsGroup.pm
@@ -185,9 +185,6 @@ sub team_channel_id {
 	my $result = $self->callAPI($url, 'GET');
 	if ($result->is_success){
 		return (decode_json($result->decoded_content))->{'value'}[0]->{'id'}
-	}else{
-		say $url;
-		die  $result->decoded_content;
 	}
 }
 
@@ -219,15 +216,12 @@ sub team_remove_member{
 
 sub team_from_group{
 	my $self = shift;
-	say "Groep ".$self->_get_id." wordt een team";
 	my $payload = {
 		'template@odata.bind' => "https://graph.microsoft.com/v1.0/teamsTemplates('educationClass')",
   		'group@odata.bind' => "https://graph.microsoft.com/v1.0/groups('" . $self->_get_id . "')"
 
 	};
-	say encode_json $payload;
 	my $url = $self->_get_graph_endpoint . "/v1.0/teams";
-	say $url;
 	# https://learn.microsoft.com/en-us/graph/teams-create-group-and-team
 	my $result = $self->callAPI($url, 'POST', $payload);
 	return $result;

--- a/lib/MsGroups.pm
+++ b/lib/MsGroups.pm
@@ -163,7 +163,7 @@ sub team_create {
 }
 
 sub team_archive {
-	# Om gegevens verlies te voorkomen worden teams niet verwijdert maar gearchiveerd.
+	# Om gegevens verlies te voorkomen worden teams niet verwijderd maar gearchiveerd.
 	# Archiveren is een async operatie, duurt een eeuwigheid, description daarom ook aan-
 	# passen zodat het archiveren direct duidelijk is en de group ook herkenbaar is als 
 	# zijnde gearchiveerd. Een groups heeft die property namelijk niet.
@@ -193,7 +193,7 @@ sub team_archive {
 	}
 }
 sub team_dearchive {
-	# Om gegevens verlies te voorkomen worden teams niet verwijdert maar gearchiveerd.
+	# Om gegevens verlies te voorkomen worden teams niet verwijderd maar gearchiveerd.
 	# Archiveren is een async operatie, duurt een eeuwigheid, description daarom ook aan-
 	# passen zodat het archiveren direct duidelijk is en de group ook herkenbaar is als 
 	# zijnde gearchiveerd. Een groups heeft die property namelijk niet.


### PR DESCRIPTION
Fixes #8 callApi aangepast zodat hij een aantal pogingen doet. Foutmelding wordt doorgegeven aan de caller voor ect afhandeling