### PR TITLE
Ook niet active users worden opgehaald in MsUsers

### DIFF
--- a/lib/MsUsers.pm
+++ b/lib/MsUsers.pm
@@ -16,10 +16,24 @@ extends 'MsGraph';
 
 sub users_fetch {
     my $self = shift;
+    my $showAll = shift;
     my @users;
     my @parameters;
-    push(@parameters,$self->_get_filter) if ($self->_get_filter);
     push(@parameters,$self->_get_select) if ($self->_get_select);
+    # Voeg een filter toe op accountEnabled
+    if ($self->_get_filter){
+        if ($showAll){
+            # _get_Filter en showAll -> alleen _get_filter dus
+            push(@parameters,$self->_get_filter) if ($self->_get_filter);
+        }else{
+            # filteren op active en _get_filter -> filter combineren
+            my $filter = $self->_get_filter . 'and accountEnabled eq true';
+            push(@parameters, $filter);
+        }
+    }else{
+        push(@parameters,'$filter=accountEnabled eq true') if (! $showAll);
+    }
+
     
     my $url = $self->_get_graph_endpoint . "/v1.0/users/?". join( '&', @parameters);
 


### PR DESCRIPTION
Fixes #10
Bij het maken van de URL van user_fetch wordt nu default een filter toegevoegd op active users